### PR TITLE
Add license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   "keywords": ["ip", "ipv4", "ipv6"],
   "repository": "git://github.com/whitequark/ipaddr.js",
   "main": "./lib/ipaddr",
-  "engines": { "node": ">= 0.2.5" }
+  "engines": { "node": ">= 0.2.5" },
+  "license": "MIT"
 }


### PR DESCRIPTION
Add license to package.json so that tools like [nlf](https://github.com/iandotkelly/nlf) can determine the license.
