### PR TITLE
bower.json file 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "ipaddr.js",
+  "version": "1.1.9",
+  "homepage": "https://github.com/whitequark/ipaddr.js",
+  "authors": [
+    "\"Peter Zotov <whitequark@whitequark.org>\""
+  ],
+  "description": "\"IP address manipulation library in JavaScript (CoffeeScript, actually)\"",
+  "main": "lib/ipaddr.js",
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "javscript",
+    "ip",
+    "address",
+    "ipv4",
+    "ipv6"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "ipaddr.js",
-  "version": "1.1.9",
+  "version": "1.0.1",
   "homepage": "https://github.com/whitequark/ipaddr.js",
   "authors": [
-    "\"Peter Zotov <whitequark@whitequark.org>\""
+    "Peter Zotov <whitequark@whitequark.org>"
   ],
-  "description": "\"IP address manipulation library in JavaScript (CoffeeScript, actually)\"",
+  "description": "IP address manipulation library in JavaScript (CoffeeScript, actually)",
   "main": "lib/ipaddr.js",
   "moduleType": [
     "globals",


### PR DESCRIPTION
bower.json file needed for scaffolding tools i.e html script parsers and minfication tools.

Makes it easier for people who use $ bower install ipaddr , to then read the bower.json file & see that the main file the want is lib/ipaddr.js

