### PR TITLE
Revert "Bump nodeunit dependency to ~0.8.2 to fix tests with node > 0…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "~1.6",
-    "nodeunit": "~0.8.2",
+    "nodeunit": "~0.5.3",
     "uglify-js": "latest"
   },
   "scripts": {


### PR DESCRIPTION
@scop, this broke tests, so I'm reverting it. That's all what happens with nodeunit 0.8.2:

```
$ ./node_modules/.bin/cake test

OK: 0 assertions (1ms)
TAP version 13
1..0
# time=94.617ms
```