### PR TITLE
Require nodeunit >=0.8.2 <0.8.7 to fix tests with node > 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "~1.6",
-    "nodeunit": "~0.5.3",
+    "nodeunit": ">=0.8.2 <0.8.7",
     "uglify-js": "latest"
   },
   "scripts": {


### PR DESCRIPTION
>= 0.8.2 is required by node > 0.11, and < 0.8.7 to keep the test suite working in the first place.