### PR TITLE
Introduce parseBinary to parse both IPv4 and IPv6 inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,20 +164,20 @@ addr.octets // => [192, 168, 1, 1]
 
 IPv4 and IPv6 can be converted bidirectionally to and from network byte order (MSB) byte arrays.
 
-The `parseBytes()` method will take an array and create an appropriate IPv4 or IPv6 object
+The `fromByteArray()` method will take an array and create an appropriate IPv4 or IPv6 object
 if the input satisfies the requirements. For IPv4 it has to be an array of four 8-bit values,
 while for IPv6 it has to be an array of sixteen 8-bit values.
 
 For example:
 ```js
-var addr = ipaddr.parseBytes([0x7f, 0, 0, 1]);
+var addr = ipaddr.fromByteArray([0x7f, 0, 0, 1]);
 addr.toString(); // => "127.0.0.1"
 ```
 
 or
 
 ```js
-var addr = ipaddr.parseBytes([0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+var addr = ipaddr.fromByteArray([0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
 addr.toString(); // => "2001:db8::1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,3 +159,46 @@ To access the underlying representation of the address, use `addr.octets`.
 var addr = ipaddr.parse("192.168.1.1");
 addr.octets // => [192, 168, 1, 1]
 ```
+
+#### Conversion
+
+IPv4 and IPv6 can be converted bidirectionally to and from network byte order (MSB) byte arrays.
+
+The `parseBytes()` method will take an array and create an appropriate IPv4 or IPv6 object
+if the input satisfies the requirements. For IPv4 it has to be an array of four 8-bit values,
+while for IPv6 it has to be an array of eight 16-bit or sixteen 8-bit values.
+
+For example:
+```js
+var addr = ipaddr.parseBytes([0x7f, 0, 0, 1]);
+addr.toString(); // => "127.0.0.1"
+```
+
+or
+
+```js
+var addr = ipaddr.parseBytes([0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+addr.toString(); // => "2001:db8::1"
+```
+
+or
+
+```js
+var addr = ipaddr.parseBytes([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1]);
+addr.toString(); // => "2001:db8::1"
+```
+
+Both objects also offer a `toByteArray()` method, which returns an array in network byte order (MSB).
+
+For example:
+```js
+var addr = ipaddr.parse("127.0.0.1");
+addr.toByteArray(); // => [0x7f, 0, 0, 1]
+```
+
+or
+
+```js
+var addr = ipaddr.parse("2001:db8::1");
+addr.toByteArray(); // => [0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ IPv4 and IPv6 can be converted bidirectionally to and from network byte order (M
 
 The `parseBytes()` method will take an array and create an appropriate IPv4 or IPv6 object
 if the input satisfies the requirements. For IPv4 it has to be an array of four 8-bit values,
-while for IPv6 it has to be an array of eight 16-bit or sixteen 8-bit values.
+while for IPv6 it has to be an array of sixteen 8-bit values.
 
 For example:
 ```js
@@ -178,13 +178,6 @@ or
 
 ```js
 var addr = ipaddr.parseBytes([0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
-addr.toString(); // => "2001:db8::1"
-```
-
-or
-
-```js
-var addr = ipaddr.parseBytes([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1]);
 addr.toString(); // => "2001:db8::1"
 ```
 

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -41,7 +41,8 @@ ipaddr.subnetMatch = (address, rangeList, defaultName='unicast') ->
 
 # An IPv4 address (RFC791).
 class ipaddr.IPv4
-  # Constructs a new IPv4 address from an array of four octets.
+  # Constructs a new IPv4 address from an array of four octets
+  # in network order (MSB first)
   # Verifies the input.
   constructor: (octets) ->
     if octets.length != 4
@@ -61,7 +62,7 @@ class ipaddr.IPv4
   toString: ->
     return @octets.join "."
 
-  # Returns an array of byte-sized values in network order
+  # Returns an array of byte-sized values in network order (MSB first)
   toByteArray: ->
     return @octets.slice(0) # octets.clone
 
@@ -145,7 +146,8 @@ ipaddr.IPv4.parser = (string) ->
 
 # An IPv6 address (RFC2460)
 class ipaddr.IPv6
-  # Constructs an IPv6 address from an array of eight 16-bit parts.
+  # Constructs an IPv6 address from an array of eight 16-bit parts
+  # in network order (MSB first).
   # Throws an error if the input is invalid.
   constructor: (parts) ->
     if parts.length != 8
@@ -198,7 +200,7 @@ class ipaddr.IPv6
 
     return compactStringParts.join ":"
 
-  # Returns an array of byte-sized values in network order
+  # Returns an array of byte-sized values in network order (MSB first)
   toByteArray: ->
     bytes = []
     for part in @parts
@@ -387,6 +389,7 @@ ipaddr.parseCIDR = (string) ->
     catch e
       throw new Error "ipaddr: the address has neither IPv6 nor IPv4 CIDR format"
 
+# Try to parse an array in network order (MSB first) for IPv4 and IPv6
 ipaddr.parseBinary = (bytes) ->
   length = bytes.length
   if length == 4

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -147,17 +147,21 @@ ipaddr.IPv4.parser = (string) ->
 # An IPv6 address (RFC2460)
 class ipaddr.IPv6
   # Constructs an IPv6 address from an array of eight 16-bit parts
-  # in network order (MSB first).
+  # or sixteen 8-bit parts in network order (MSB first).
   # Throws an error if the input is invalid.
   constructor: (parts) ->
-    if parts.length != 8
-      throw new Error "ipaddr: ipv6 part count should be 8"
+    if parts.length == 16
+      @parts = []
+      for i in [0..14] by 2
+        @parts.push((parts[i] << 8) | parts[i + 1])
+    else if parts.length == 8
+      @parts = parts
+    else
+      throw new Error "ipaddr: ipv6 part count should be 8 or 16"
 
-    for part in parts
+    for part in @parts
       if !(0 <= part <= 0xffff)
         throw new Error "ipaddr: ipv6 part should fit to two octets"
-
-    @parts = parts
 
   # The 'kind' method exists on both IPv4 and IPv6 classes.
   kind: ->
@@ -394,7 +398,7 @@ ipaddr.parseBytes = (bytes) ->
   length = bytes.length
   if length == 4
     return new ipaddr.IPv4(bytes)
-  else if length == 8
+  else if length == 8 or length == 16
     return new ipaddr.IPv6(bytes)
   else
     throw new Error "ipaddr: the binary input is neither an IPv6 nor IPv4 address"

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -398,7 +398,7 @@ ipaddr.parseBytes = (bytes) ->
   length = bytes.length
   if length == 4
     return new ipaddr.IPv4(bytes)
-  else if length == 8 or length == 16
+  else if length == 16
     return new ipaddr.IPv6(bytes)
   else
     throw new Error "ipaddr: the binary input is neither an IPv6 nor IPv4 address"

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -387,6 +387,15 @@ ipaddr.parseCIDR = (string) ->
     catch e
       throw new Error "ipaddr: the address has neither IPv6 nor IPv4 CIDR format"
 
+ipaddr.parseBinary = (bytes) ->
+  length = bytes.length
+  if length == 4
+    return new ipaddr.IPv4(bytes)
+  else if length == 8
+    return new ipaddr.IPv6(bytes)
+  else
+    throw new Error "ipaddr: the binary input is neither an IPv6 nor IPv4 address"
+
 # Parse an address and return plain IPv4 address if it is an IPv4-mapped address
 ipaddr.process = (string) ->
   addr = @parse(string)

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -390,7 +390,7 @@ ipaddr.parseCIDR = (string) ->
       throw new Error "ipaddr: the address has neither IPv6 nor IPv4 CIDR format"
 
 # Try to parse an array in network order (MSB first) for IPv4 and IPv6
-ipaddr.parseBinary = (bytes) ->
+ipaddr.parseBytes = (bytes) ->
   length = bytes.length
   if length == 4
     return new ipaddr.IPv4(bytes)

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -394,7 +394,7 @@ ipaddr.parseCIDR = (string) ->
       throw new Error "ipaddr: the address has neither IPv6 nor IPv4 CIDR format"
 
 # Try to parse an array in network order (MSB first) for IPv4 and IPv6
-ipaddr.parseBytes = (bytes) ->
+ipaddr.fromByteArray = (bytes) ->
   length = bytes.length
   if length == 4
     return new ipaddr.IPv4(bytes)

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -280,3 +280,10 @@ module.exports =
     test.equal(ipaddr.subnetMatch(new ipaddr.IPv4([1,2,3,4]), {}, false), false)
     test.equal(ipaddr.subnetMatch(new ipaddr.IPv4([1,2,3,4]), {subnet: []}, false), false)
     test.done()
+
+  'is able to determine IP address type from binary input': (test) ->
+    test.equal(ipaddr.parseBinary([0x7f, 0, 0, 1]).kind(), 'ipv4')
+    test.equal(ipaddr.parseBinary([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
+    test.throws ->
+      ipaddr.parseBinary([1])
+    test.done()

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -106,9 +106,16 @@ module.exports =
     test.equal(ipaddr.IPv4.parse('8.8.8.8').range(),         'unicast')
     test.done()
 
-  'can construct IPv6 from parts': (test) ->
+  'can construct IPv6 from 16bit parts': (test) ->
     test.doesNotThrow ->
       new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1])
+    test.done()
+
+  'can construct IPv6 from 8bit parts': (test) ->
+    test.doesNotThrow ->
+      new ipaddr.IPv6([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    test.deepEqual(new ipaddr.IPv6([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+      new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]))
     test.done()
 
   'refuses to construct invalid IPv6': (test) ->
@@ -116,6 +123,8 @@ module.exports =
       new ipaddr.IPv6([0xfffff, 0, 0, 0, 0, 0, 0, 1])
     test.throws ->
       new ipaddr.IPv6([0xfffff, 0, 0, 0, 0, 0, 1])
+    test.throws ->
+      new ipaddr.IPv6([0xffff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
     test.done()
 
   'converts IPv6 to string correctly': (test) ->
@@ -284,6 +293,7 @@ module.exports =
   'is able to determine IP address type from binary input': (test) ->
     test.equal(ipaddr.parseBytes([0x7f, 0, 0, 1]).kind(), 'ipv4')
     test.equal(ipaddr.parseBytes([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
+    test.equal(ipaddr.parseBytes([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).kind(), 'ipv6')
     test.throws ->
       ipaddr.parseBytes([1])
     test.done()

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -290,9 +290,9 @@ module.exports =
     test.equal(ipaddr.subnetMatch(new ipaddr.IPv4([1,2,3,4]), {subnet: []}, false), false)
     test.done()
 
-  'is able to determine IP address type from binary input': (test) ->
-    test.equal(ipaddr.parseBytes([0x7f, 0, 0, 1]).kind(), 'ipv4')
-    test.equal(ipaddr.parseBytes([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).kind(), 'ipv6')
+  'is able to determine IP address type from byte array input': (test) ->
+    test.equal(ipaddr.fromByteArray([0x7f, 0, 0, 1]).kind(), 'ipv4')
+    test.equal(ipaddr.fromByteArray([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).kind(), 'ipv6')
     test.throws ->
-      ipaddr.parseBytes([1])
+      ipaddr.fromByteArray([1])
     test.done()

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -292,7 +292,6 @@ module.exports =
 
   'is able to determine IP address type from binary input': (test) ->
     test.equal(ipaddr.parseBytes([0x7f, 0, 0, 1]).kind(), 'ipv4')
-    test.equal(ipaddr.parseBytes([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
     test.equal(ipaddr.parseBytes([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).kind(), 'ipv6')
     test.throws ->
       ipaddr.parseBytes([1])

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -282,8 +282,8 @@ module.exports =
     test.done()
 
   'is able to determine IP address type from binary input': (test) ->
-    test.equal(ipaddr.parseBinary([0x7f, 0, 0, 1]).kind(), 'ipv4')
-    test.equal(ipaddr.parseBinary([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
+    test.equal(ipaddr.parseBytes([0x7f, 0, 0, 1]).kind(), 'ipv4')
+    test.equal(ipaddr.parseBytes([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
     test.throws ->
-      ipaddr.parseBinary([1])
+      ipaddr.parseBytes([1])
     test.done()


### PR DESCRIPTION
This patch adds a new method `ipaddr.parseBinary()` which can accept both IPv4 octets and IPv6 parts and will return the proper object.