### PR TITLE
Support both 8x16bit and 16x8bit IPv6 binary inputs in ipaddr.IPv6()

### DIFF
--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -145,17 +145,22 @@ ipaddr.IPv4.parser = (string) ->
 
 # An IPv6 address (RFC2460)
 class ipaddr.IPv6
-  # Constructs an IPv6 address from an array of eight 16-bit parts.
+  # Constructs an IPv6 address from an array of eight 16-bit parts
+  # or sixteen 8-bit parts.
   # Throws an error if the input is invalid.
   constructor: (parts) ->
-    if parts.length != 8
-      throw new Error "ipaddr: ipv6 part count should be 8"
+    if parts.length == 16
+      @parts = []
+      for i in [0..14] by 2
+        @parts.push((parts[i] << 8) | parts[i + 1])
+    else if parts.length == 8
+      @parts = parts
+    else
+      throw new Error "ipaddr: ipv6 part count should be 8 or 16"
 
-    for part in parts
+    for part in @parts
       if !(0 <= part <= 0xffff)
         throw new Error "ipaddr: ipv6 part should fit to two octets"
-
-    @parts = parts
 
   # The 'kind' method exists on both IPv4 and IPv6 classes.
   kind: ->
@@ -391,7 +396,7 @@ ipaddr.parseBinary = (bytes) ->
   length = bytes.length
   if length == 4
     return new ipaddr.IPv4(bytes)
-  else if length == 8
+  else if length == 8 or length == 16
     return new ipaddr.IPv6(bytes)
   else
     throw new Error "ipaddr: the binary input is neither an IPv6 nor IPv4 address"

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -387,6 +387,15 @@ ipaddr.parseCIDR = (string) ->
     catch e
       throw new Error "ipaddr: the address has neither IPv6 nor IPv4 CIDR format"
 
+ipaddr.parseBinary = (bytes) ->
+  length = bytes.length
+  if length == 4
+    return new ipaddr.IPv4(bytes)
+  else if length == 8
+    return new ipaddr.IPv6(bytes)
+  else
+    throw new Error "ipaddr: the binary input is neither an IPv6 nor IPv4 address"
+
 # Parse an address and return plain IPv4 address if it is an IPv4-mapped address
 ipaddr.process = (string) ->
   addr = @parse(string)

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -280,3 +280,10 @@ module.exports =
     test.equal(ipaddr.subnetMatch(new ipaddr.IPv4([1,2,3,4]), {}, false), false)
     test.equal(ipaddr.subnetMatch(new ipaddr.IPv4([1,2,3,4]), {subnet: []}, false), false)
     test.done()
+
+  'is able to determine IP address type from binary input': (test) ->
+    test.equal(ipaddr.parseBinary([0x7f, 0, 0, 1]).kind(), 'ipv4')
+    test.equal(ipaddr.parseBinary([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
+    test.throws ->
+      ipaddr.parseBinary([1])
+    test.done()

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -111,11 +111,20 @@ module.exports =
       new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1])
     test.done()
 
+  'can construct IPv6 from binary': (test) ->
+    test.doesNotThrow ->
+      new ipaddr.IPv6([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    test.deepEqual(new ipaddr.IPv6([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+      new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]))
+    test.done()
+
   'refuses to construct invalid IPv6': (test) ->
     test.throws ->
       new ipaddr.IPv6([0xfffff, 0, 0, 0, 0, 0, 0, 1])
     test.throws ->
       new ipaddr.IPv6([0xfffff, 0, 0, 0, 0, 0, 1])
+    test.throws ->
+      new ipaddr.IPv6([0xffff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
     test.done()
 
   'converts IPv6 to string correctly': (test) ->
@@ -284,6 +293,7 @@ module.exports =
   'is able to determine IP address type from binary input': (test) ->
     test.equal(ipaddr.parseBinary([0x7f, 0, 0, 1]).kind(), 'ipv4')
     test.equal(ipaddr.parseBinary([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]).kind(), 'ipv6')
+    test.equal(ipaddr.parseBinary([0x20, 0x01, 0xd, 0xb8, 0xf5, 0x3a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).kind(), 'ipv6')
     test.throws ->
       ipaddr.parseBinary([1])
     test.done()


### PR DESCRIPTION
For the moment this is based branched off my other PR https://github.com/whitequark/ipaddr.js/pull/34, hence you'll see both changes below.