### PR TITLE
Reduced npm package size by excluding tests, bower and CI files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "scripts": {
     "test": "cake build test"
   },
+  "files": [
+    "lib/",
+    "ipaddr.min.js"
+  ],
   "keywords": ["ip", "ipv4", "ipv6"],
   "repository": "git://github.com/whitequark/ipaddr.js",
   "main": "./lib/ipaddr.js",


### PR DESCRIPTION
Files included in package after this change (output from [this tool](https://gist.github.com/anonymous/9d6d38b06d0a88eed4e3b4c648a9f5c1)):

```
package/package.json
package/ipaddr.min.js
package/LICENSE
package/README.md
package/lib/ipaddr.js
package/lib/ipaddr.js.d.ts
```