### PR TITLE
Correct Typescript definition for subnetMatch

### DIFF
--- a/lib/ipaddr.js.d.ts
+++ b/lib/ipaddr.js.d.ts
@@ -26,8 +26,8 @@ declare module "ipaddr.js" {
         export function parse(addr: string): IPv4 | IPv6;
         export function parseCIDR(mask: string): [IPv4 | IPv6, number];
         export function process(address: string): IPv4 | IPv6;
-        export function subnetMatch(addr: IPv4, rangeList: RangeList<IPv4>, defaultName?: string): boolean;
-        export function subnetMatch(addr: IPv6, rangeList: RangeList<IPv6>, defaultName?: string): boolean;
+        export function subnetMatch(addr: IPv4, rangeList: RangeList<IPv4>, defaultName?: string): string;
+        export function subnetMatch(addr: IPv6, rangeList: RangeList<IPv6>, defaultName?: string): string;
 
         export class IPv4 extends IP {
             static broadcastAddressFromCIDR(addr: string): IPv4;
@@ -44,7 +44,7 @@ declare module "ipaddr.js" {
             match(addr: IPv4, bits: number): boolean;
             match(mask: [IPv4, number]): boolean;
             range(): IPv4Range;
-            subnetMatch(rangeList: RangeList<IPv4>, defaultName?: string): boolean;
+            subnetMatch(rangeList: RangeList<IPv4>, defaultName?: string): string;
             toIPv4MappedAddress(): IPv6;
         }
 
@@ -62,7 +62,7 @@ declare module "ipaddr.js" {
             match(addr: IPv6, bits: number): boolean;
             match(mask: [IPv6, number]): boolean;
             range(): IPv6Range;
-            subnetMatch(rangeList: RangeList<IPv6>, defaultName?: string): boolean;
+            subnetMatch(rangeList: RangeList<IPv6>, defaultName?: string): string;
             toIPv4Address(): IPv4;
         }
     }


### PR DESCRIPTION
The rangeName returned in the code is a string, not a boolean.