### PR TITLE
CoffeeScript on NPM has moved to "coffeescript (no hyphen)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "coffee-script": "~1.12.6",
+    "coffeescript": "~2.3.1",
     "uglify-js": "~3.0.19",
     "nodeunit": ">=0.8.2 <0.8.7"
   },


### PR DESCRIPTION
Due to some deps we get deprecation warnings about coffeescript and the hyphen in between.
Maybe we could also update to the newest coffeescript version :). I am not a coffeescript user
so I am not sure if the new milestone version breaks anything.

Thanks in advance
Oliver