### PR TITLE
Update Typescript range definitions in include 'unicast'.

### DIFF
--- a/lib/ipaddr.js.d.ts
+++ b/lib/ipaddr.js.d.ts
@@ -2,8 +2,8 @@
 
 declare module "ipaddr.js" {
 
-    type IPv4Range = 'unspecified' | 'broadcast' | 'multicast' | 'linkLocal' | 'loopback' | 'carrierGradeNat' | 'private' | 'reserved';
-    type IPv6Range = 'unspecified' | 'linkLocal' | 'multicast' | 'loopback' | 'uniqueLocal' | 'ipv4Mapped' | 'rfc6145' | 'rfc6052' | '6to4' | 'teredo' | 'reserved';
+    type IPv4Range = 'unicast' | 'unspecified' | 'broadcast' | 'multicast' | 'linkLocal' | 'loopback' | 'carrierGradeNat' | 'private' | 'reserved';
+    type IPv6Range = 'unicast' | 'unspecified' | 'linkLocal' | 'multicast' | 'loopback' | 'uniqueLocal' | 'ipv4Mapped' | 'rfc6145' | 'rfc6052' | '6to4' | 'teredo' | 'reserved';
 
     interface RangeList<T> {
         [name: string]: [T, number] | [T, number][];


### PR DESCRIPTION
The Typescript type definitions for ranges didn't include the "default" `unicast` value. This PR adds them.