### PR TITLE
Add 0 padding to normalized IP address stringify

### DIFF
--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -232,6 +232,17 @@ class ipaddr.IPv6
   # Returns the address in expanded format with all zeroes included, like
   # 2001:db8:8:66:0:0:0:1
   toNormalizedString: ->
+    addr = (part.toString(16) for part in @parts).join ":"
+
+    suffix = ''
+    if @zoneId
+      suffix = '%' + @zoneId
+
+    return addr + suffix
+
+  # Returns the address in expanded format with all zeroes included, like
+  # 2001:db8:8:66:0:0:0:1
+  toFixedLengthString: ->
     addr = (part.toString(16).padStart(4, '0') for part in @parts).join ":"
 
     suffix = ''

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -232,7 +232,7 @@ class ipaddr.IPv6
   # Returns the address in expanded format with all zeroes included, like
   # 2001:db8:8:66:0:0:0:1
   toNormalizedString: ->
-    addr = (part.toString(16) for part in @parts).join ":"
+    addr = (part.toString(16).padStart(4, '0') for part in @parts).join ":"
 
     suffix = ''
     if @zoneId

--- a/src/ipaddr.coffee
+++ b/src/ipaddr.coffee
@@ -241,7 +241,7 @@ class ipaddr.IPv6
     return addr + suffix
 
   # Returns the address in expanded format with all zeroes included, like
-  # 2001:db8:8:66:0:0:0:1
+  # 2001:0db8:0008:0066:0000:0000:0000:0001
   toFixedLengthString: ->
     addr = (part.toString(16).padStart(4, '0') for part in @parts).join ":"
 

--- a/test/ipaddr.test.coffee
+++ b/test/ipaddr.test.coffee
@@ -126,7 +126,7 @@ module.exports =
       test.equal(ipaddr.IPv4.isValidFourPartDecimal('192.0000168.100.2'), false)
       test.equal(ipaddr.IPv4.isValidFourPartDecimal('192.168.100.00000002'), false)
       test.equal(ipaddr.IPv4.isValidFourPartDecimal('192.168.100.20000000'), false)
-      test.done() 
+      test.done()
 
   'can construct IPv6 from 16bit parts': (test) ->
     test.doesNotThrow ->
@@ -152,6 +152,7 @@ module.exports =
   'converts IPv6 to string correctly': (test) ->
     addr = new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1])
     test.equal(addr.toNormalizedString(), '2001:db8:f53a:0:0:0:0:1')
+    test.equal(addr.toFixedLengthString(), '2001:0db8:f53a:0000:0000:0000:0000:0001')
     test.equal(addr.toString(), '2001:db8:f53a::1')
     test.equal(new ipaddr.IPv6([0, 0, 0, 0, 0, 0, 0, 0]).toString(), '::')
     test.equal(new ipaddr.IPv6([0, 0, 0, 0, 0, 0, 0, 1]).toString(), '::1')


### PR DESCRIPTION
A fully normalized string would have the same characters in each part, including 0s.

This change fixes that. 

This could also be another function or an option to the function instead.

see [python's equivalent function](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv6Address.exploded) for reference