### PR TITLE
Adds TypeScript type guards for address versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - "8"
   - "10"
   - "12"
+  - "14"
 
 script:
     - npm run lint

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or
 
 ## Older Node support
 
-Use the latest 1.x release for versions of nodejs older than 8.
+Use the latest 1.x release for versions of nodejs older than 10.
 
 ## API
 

--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -893,6 +893,16 @@
         }
     };
 
+    // TypeScript type guard for ipv4 case
+    ipaddr.isIPv4 = function (addr) {
+        return addr.kind() === 'ipv4';
+    };
+
+    // TypeScript type guard for ipv6 case
+    ipaddr.isIPv6 = function (addr) {
+        return addr.kind() === 'ipv6';
+    };
+
     // Export for both the CommonJS and browser-like environment
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = ipaddr;

--- a/lib/ipaddr.js.d.ts
+++ b/lib/ipaddr.js.d.ts
@@ -22,6 +22,8 @@ declare module "ipaddr.js" {
         export function process(addr: string): IPv4 | IPv6;
         export function subnetMatch(addr: IPv4, rangeList: RangeList<IPv4>, defaultName?: string): string;
         export function subnetMatch(addr: IPv6, rangeList: RangeList<IPv6>, defaultName?: string): string;
+        export function isIPv4(addr: IPv4 | IPv6): addr is IPv4;
+        export function isIPv6(addr: IPv4 | IPv6): addr is IPv6;
 
         export class IPv4 extends IP {
             static broadcastAddressFromCIDR(addr: string): IPv4;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "repository": "git://github.com/whitequark/ipaddr.js",
   "main": "./lib/ipaddr.js",
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "license": "MIT",
   "types": "./lib/ipaddr.js.d.ts"

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -42,6 +42,12 @@ describe('ipaddr', () => {
         done();
     })
 
+    it('type guard returns correct kind for IPv4', (done) => {
+        let addr = new ipaddr.IPv4([1, 2, 3, 4]);
+        assert.equal(ipaddr.isIPv4(addr), true);
+        done();
+    })
+
     it('allows to access IPv4 octets', (done) => {
         let addr = new ipaddr.IPv4([42, 0, 0, 0]);
         assert.equal(addr.octets[0], 42);
@@ -284,6 +290,12 @@ describe('ipaddr', () => {
     it('returns correct kind for IPv6', (done) => {
         let addr = new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]);
         assert.equal(addr.kind(), 'ipv6');
+        done();
+    })
+
+    it('type guard returns correct kind for IPv6', (done) => {
+        let addr = new ipaddr.IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]);
+        assert.equal(ipaddr.isIPv6(addr), true);
         done();
     })
 


### PR DESCRIPTION
Hi folks!
Here are functions for more ergonomic typed programming.
```typescript
const addr: IPv4 | IPv6 = parse('192.168.1.1');
if (isIPv4(addr)) {
  // addr: IPv4
} else {
  // addr: IPv6
}

if (isIPv6(addr)) {
  // addr: IPv6
} else {
  // addr: IPv4
}
```