### PR TITLE
Add GitHub Actions Tagged Release

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,37 @@
+name: Tagged Release Distribution
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  all_jobs:
+    name: Tests, Builds, Release Uploads
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: "14.x"
+      - name: Install (Dev)Dependencies
+        run: npm install
+      - name: Run Mocha Tests
+        run: npm run test
+      - name: Run Lint
+        run: npm run lint
+      - name: Run Build
+        run: npm run build
+      - name: GitHub Releases
+        id: github_releases
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            ipaddr.min.js
+          body: This is an auto-generated tagged release.  Use NPM to get the latest version, or the attached min.js file for browser usage.
+          prerelease: ${{ endsWith(github.ref, 'alpha') || endsWith(github.ref, 'beta') }}


### PR DESCRIPTION
Only if you want to use this.

This will, upon a new push of a tag matching a semver format (v[0-9]+.[0-9]+.[0-9]+) then it will do its tests, lint, build, and generate a new GitHub release, adding in the `ipaddr.min.js` file as an attachment.  This only affect the GitHub Releases, which to this date shows 1.0.3 from 2015.

I've performed the test on my own repo, feel free to visit the forked repo and head into releases to see it.

_As a side note, Not that there was anything wrong with putting that file at the root directory, but normally generated/minified files are not stored, and should be generated manually if they are cloning the repo as one may have forgotten to generate the minified build file with the added changes.  That way people will know that the released min.js file under releases will work.  We're humans, and sometimes what is committed to the master may not be working at all times._

Signed-off-by: Kenneth Tran <kennethtran93@users.noreply.github.com>