### PR TITLE
add GitHub Actions for CI tests

### DIFF
--- a/.github/workflows/ci-test-win.yml
+++ b/.github/workflows/ci-test-win.yml
@@ -1,0 +1,35 @@
+name: CI Tests - Win
+
+on: [ push, pull_request ]
+
+jobs:
+
+  ci-test-win:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ windows-latest ]
+        node-version: [12.x, 14.x]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout Code
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-node@v1
+      name: Use Node.js ${{ matrix.node-version }}
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install
+      run: npm install
+
+    - name: Test
+      run: npm run test
+
+      env:
+        CI: true

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,35 @@
+name: CI Tests
+
+on: [ push, pull_request ]
+
+jobs:
+
+  ci-test:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        node-version: [12.x, 14.x]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout Code
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-node@v1
+      name: Use Node.js ${{ matrix.node-version }}
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install
+      run: npm install
+
+    - name: Test
+      run: npm run test
+
+      env:
+        CI: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on: [ push, pull_request ]
+
+jobs:
+
+  lint:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout Code
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-node@v1
+      name: Use Node.js ${{ matrix.node-version }}
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install
+      run: npm install
+
+    - name: Lint
+      run: npm run lint
+
+      env:
+        CI: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ipaddr.js — an IPv6 and IPv4 address manipulation library
 
-[![Build Status](https://travis-ci.org/whitequark/ipaddr.js.svg)](https://travis-ci.org/whitequark/ipaddr.js)
+[![Build Status](https://github.com/whitequark/ipaddr.js/workflows/CI%20Tests/badge.svg)](https://github.com/whitequark/ipaddr.js/actions?query=workflow%3A%22CI+Tests%22)
 
 ipaddr.js is a small (1.9K minified and gzipped) library for manipulating
 IP addresses in JavaScript environments. It runs on both CommonJS runtimes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ipaddr.js — an IPv6 and IPv4 address manipulation library [![Build Status](https://travis-ci.org/whitequark/ipaddr.js.svg)](https://travis-ci.org/whitequark/ipaddr.js)
+# ipaddr.js — an IPv6 and IPv4 address manipulation library
+
+[![Build Status](https://travis-ci.org/whitequark/ipaddr.js.svg)](https://travis-ci.org/whitequark/ipaddr.js)
 
 ipaddr.js is a small (1.9K minified and gzipped) library for manipulating
 IP addresses in JavaScript environments. It runs on both CommonJS runtimes


### PR DESCRIPTION
Why add GitHub Actions support?

- I contributed the Travis CI to this repo.
- Travis CI test execution times have increased sharply in the past months
- execution time for Travis CI on this PR: 50 seconds, wall clock duration 1 min 45 sec
- execution time for [GitHub Actions](https://github.com/msimerson/ipaddr.js/actions) on this PR: 9 seconds.
- see the GitHub results under the Actions tab [in my fork](https://github.com/msimerson/ipaddr.js/actions)
- adds tests on Windows platform
- Travis is still enabled. I recommend using them both for now, until you see how dog slow Travis is, trust that GitHub Actions is serving the same good purpose, and finally delete .travis.yml.