### PR TITLE
Update ipaddr.js

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -734,7 +734,7 @@
         // Deprecated: use toRFC5952String() instead.
         IPv6.prototype.toString = function () {
             // Replace the first sequence of 1 or more '0' parts with '::'
-            return this.toNormalizedString().replace(/((^|:)(0(:|$))+)/, '::');
+            return this.toNormalizedString().replace(/(^|:)(0[:$]?)+/, '::');
         };
 
         return IPv6;


### PR DESCRIPTION
Fix some unit tests when parsing inaccurate IPv4-mapped IPv6 CIDRs outside of the IPv4 CIDR range into IPv6
Examples:
0:0:0:0:0:0:0:0%2
0:0:0:0:0:0:0:0%eth0
0:0:0:0:0:0:0:0%2
0:0:0:0:0:0:0:0%eth0
0:0:0:0:0:0:0:0%2
ffed:0:0:0:0:0:0:0%eth0
0:0:0:0:0:0:0:0%2
ffed:0:0:0:0:0:0:0%eth0
0:0:0:0:0:0:0:0%2
0:0:0:0:0:0:0:0%eth0