### PR TITLE
Add IANA reserved IPv6 addresses of 2001 space

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -545,7 +545,12 @@
             // RFC6052, RFC6146
             teredo: [new IPv6([0x2001, 0, 0, 0, 0, 0, 0, 0]), 32],
             // RFC4291
-            reserved: [[new IPv6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0]), 32]]
+            reserved: [[new IPv6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0]), 32]],
+            benchmarking: [new IPv6([0x2001, 0x2, 0, 0, 0, 0, 0, 0]), 48],
+            amt: [new IPv6([0x2001, 0x3, 0, 0, 0, 0, 0, 0]), 32],
+            as112v6: [new IPv6([0x2001, 0x4, 0x112, 0, 0, 0, 0, 0]), 48],
+            deprecated: [new IPv6([0x2001, 0x10, 0, 0, 0, 0, 0, 0]), 28],
+            orchid2: [new IPv6([0x2001, 0x20, 0, 0, 0, 0, 0, 0]), 28]
         };
 
         // Checks if this address is an IPv4-mapped IPv6 address.

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -415,6 +415,11 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv6.parse('64:ff9b::1234').range(), 'rfc6052');
         assert.equal(ipaddr.IPv6.parse('2002:1f63:45e8::1').range(), '6to4');
         assert.equal(ipaddr.IPv6.parse('2001::4242').range(), 'teredo');
+        assert.equal(ipaddr.IPv6.parse('2001:2::').range(), 'benchmarking');
+        assert.equal(ipaddr.IPv6.parse('2001:3::').range(), 'amt');
+        assert.equal(ipaddr.IPv6.parse('2001:4:112::').range(), 'as112v6');
+        assert.equal(ipaddr.IPv6.parse('2001:10::').range(), 'deprecated');
+        assert.equal(ipaddr.IPv6.parse('2001:20::').range(), 'orchid2');
         assert.equal(ipaddr.IPv6.parse('2001:db8::3210').range(), 'reserved');
         assert.equal(ipaddr.IPv6.parse('2001:470:8:66::1').range(), 'unicast');
         assert.equal(ipaddr.IPv6.parse('2001:470:8:66::1%z').range(), 'unicast');


### PR DESCRIPTION
According to https://www.iana.org/assignments/ipv6-address-space/ipv6-address-space.xml Notes 9 through 13, the following IPv6 addresses should be marked as reserved:
* 2001:2:: 
* 2001:3:: 
* 2001:4:112:: 
* 2001:10:: 
* 2001:20:: 