### PR TITLE
add more reserved IP address ranges

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -207,7 +207,16 @@
                 [new IPv4([198, 51, 100, 0]), 24],
                 [new IPv4([203, 0, 113, 0]), 24],
                 [new IPv4([240, 0, 0, 0]), 4]
-            ]
+            ],
+            // RFC7534, RFC7535
+            as112: [
+                [new IPv4([192, 175, 48, 0]), 24],
+                [new IPv4([192, 31, 196, 0]), 24],
+            ],
+            // RFC7450
+            amt: [
+                [new IPv4([192, 52, 193, 0]), 24],
+            ],
         };
 
         // The 'kind' method exists on both IPv4 and IPv6 classes.
@@ -537,6 +546,8 @@
             loopback: [new IPv6([0, 0, 0, 0, 0, 0, 0, 1]), 128],
             uniqueLocal: [new IPv6([0xfc00, 0, 0, 0, 0, 0, 0, 0]), 7],
             ipv4Mapped: [new IPv6([0, 0, 0, 0, 0, 0xffff, 0, 0]), 96],
+            // RFC6666
+            discard: [new IPv6([0x100, 0, 0, 0, 0, 0, 0, 0]), 64],
             // RFC6145
             rfc6145: [new IPv6([0, 0, 0, 0, 0xffff, 0, 0, 0]), 96],
             // RFC6052
@@ -545,13 +556,23 @@
             '6to4': [new IPv6([0x2002, 0, 0, 0, 0, 0, 0, 0]), 16],
             // RFC6052, RFC6146
             teredo: [new IPv6([0x2001, 0, 0, 0, 0, 0, 0, 0]), 32],
-            // RFC4291
-            reserved: [[new IPv6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0]), 32]],
+            // RFC5180
             benchmarking: [new IPv6([0x2001, 0x2, 0, 0, 0, 0, 0, 0]), 48],
+            // RFC7450
             amt: [new IPv6([0x2001, 0x3, 0, 0, 0, 0, 0, 0]), 32],
-            as112v6: [new IPv6([0x2001, 0x4, 0x112, 0, 0, 0, 0, 0]), 48],
+            as112v6: [
+                [new IPv6([0x2001, 0x4, 0x112, 0, 0, 0, 0, 0]), 48],
+                [new IPv6([0x2620, 0x4f, 0x8000, 0, 0, 0, 0, 0]), 48],
+            ],
             deprecated: [new IPv6([0x2001, 0x10, 0, 0, 0, 0, 0, 0]), 28],
-            orchid2: [new IPv6([0x2001, 0x20, 0, 0, 0, 0, 0, 0]), 28]
+            orchid2: [new IPv6([0x2001, 0x20, 0, 0, 0, 0, 0, 0]), 28],
+            droneRemoteIdProtocolEntityTags: [new IPv6([0x2001, 0x30, 0, 0, 0, 0, 0, 0]), 28],
+            reserved: [
+                // RFC3849
+                [new IPv6([0x2001, 0, 0, 0, 0, 0, 0, 0]), 23],
+                // RFC2928
+                [new IPv6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0]), 32],
+            ],
         };
 
         // Checks if this address is an IPv4-mapped IPv6 address.

--- a/lib/ipaddr.js.d.ts
+++ b/lib/ipaddr.js.d.ts
@@ -1,7 +1,7 @@
 declare module "ipaddr.js" {
-    type IPvXRangeDefaults = 'unicast' | 'unspecified' | 'multicast' | 'linkLocal' | 'loopback' | 'reserved';
-    type IPv4Range = IPvXRangeDefaults | 'broadcast' | 'carrierGradeNat' | 'private';
-    type IPv6Range = IPvXRangeDefaults | 'uniqueLocal' | 'ipv4Mapped' | 'rfc6145' | 'rfc6052' | '6to4' | 'teredo';
+    type IPvXRangeDefaults = 'unicast' | 'unspecified' | 'multicast' | 'linkLocal' | 'loopback' | 'reserved' | 'benchmarking' | 'amt';
+    type IPv4Range = IPvXRangeDefaults | 'broadcast' | 'carrierGradeNat' | 'private' | 'as112';
+    type IPv6Range = IPvXRangeDefaults | 'uniqueLocal' | 'ipv4Mapped' | 'rfc6145' | 'rfc6052' | '6to4' | 'teredo' | 'as112v6' | 'orchid2' | 'droneRemoteIdProtocolEntityTags';
 
     interface RangeList<T> {
         [name: string]: [T, number] | [T, number][];

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -150,7 +150,9 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv4.parse('10.1.0.1').range(), 'private');
         assert.equal(ipaddr.IPv4.parse('100.64.0.0').range(), 'carrierGradeNat');
         assert.equal(ipaddr.IPv4.parse('100.127.255.255').range(), 'carrierGradeNat');
+        assert.equal(ipaddr.IPv4.parse('192.52.193.1').range(), 'amt');
         assert.equal(ipaddr.IPv4.parse('192.168.2.1').range(), 'private');
+        assert.equal(ipaddr.IPv4.parse('192.175.48.0').range(), 'as112');
         assert.equal(ipaddr.IPv4.parse('224.100.0.1').range(), 'multicast');
         assert.equal(ipaddr.IPv4.parse('169.254.15.0').range(), 'linkLocal');
         assert.equal(ipaddr.IPv4.parse('127.1.1.1').range(), 'loopback');
@@ -423,6 +425,7 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv6.parse('fe80::1234:5678:abcd:0123').range(), 'linkLocal');
         assert.equal(ipaddr.IPv6.parse('ff00::1234').range(), 'multicast');
         assert.equal(ipaddr.IPv6.parse('::1').range(), 'loopback');
+        assert.equal(ipaddr.IPv6.parse('100::42').range(), 'discard');
         assert.equal(ipaddr.IPv6.parse('fc00::').range(), 'uniqueLocal');
         assert.equal(ipaddr.IPv6.parse('::ffff:192.168.1.10').range(), 'ipv4Mapped');
         assert.equal(ipaddr.IPv6.parse('::ffff:0:192.168.1.10').range(), 'rfc6145');
@@ -432,8 +435,10 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv6.parse('2001:2::').range(), 'benchmarking');
         assert.equal(ipaddr.IPv6.parse('2001:3::').range(), 'amt');
         assert.equal(ipaddr.IPv6.parse('2001:4:112::').range(), 'as112v6');
+        assert.equal(ipaddr.IPv6.parse('2620:4f:8000::').range(), 'as112v6');
         assert.equal(ipaddr.IPv6.parse('2001:10::').range(), 'deprecated');
         assert.equal(ipaddr.IPv6.parse('2001:20::').range(), 'orchid2');
+        assert.equal(ipaddr.IPv6.parse('2001:30::').range(), 'droneRemoteIdProtocolEntityTags');
         assert.equal(ipaddr.IPv6.parse('2001:db8::3210').range(), 'reserved');
         assert.equal(ipaddr.IPv6.parse('2001:470:8:66::1').range(), 'unicast');
         assert.equal(ipaddr.IPv6.parse('2001:470:8:66::1%z').range(), 'unicast');


### PR DESCRIPTION
This adds some reserved IP address ranges for both v4 and v6 which were not yet implemented. Also fixes the types for some ranges which had been added earlier.