### PR TITLE
Move to esbuild, .gitignore ipaddr.min.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 package-lock.json
+ipaddr.min.js

--- a/package.json
+++ b/package.json
@@ -7,15 +7,14 @@
   "directories": {
     "lib": "./lib"
   },
-  "dependencies": {},
   "devDependencies": {
-    "eslint": "^9.19.0",
-    "uglify-es": "*"
+    "esbuild": "^0.28.0",
+    "eslint": "^9.19.0"
   },
   "scripts": {
-    "lint": "npx eslint lib",
-    "lintfix": "npx eslint --fix lib test",
-    "build": "npx uglifyjs --compress --mangle --wrap=window -o ipaddr.min.js lib/ipaddr.js",
+    "lint": "eslint lib",
+    "lintfix": "eslint --fix lib test",
+    "build": "esbuild lib/ipaddr.js --bundle --minify --sourcemap --outfile=ipaddr.min.js",
     "test": "node --test"
   },
   "files": [


### PR DESCRIPTION
Part of #193 

- Replaces uglify-es with esbuild
- Removes redundant `npx` calls
- .gitignores the minified output, as #194 should have done