### PR TITLE
Classify IPv4-Compatible IPv6 (RFC4291 §2.5.5.1) as `ipv4Compat`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- classify IPv4-Compatible IPv6 addresses (RFC4291 §2.5.5.1, `::/96` excluding `::` and `::1`) as `ipv4Compat` instead of `unicast`, so consumers using `range() !== 'unicast'` as an SSRF safety check block `::7f00:1`, `::a9fe:a9fe`, etc. — the pure-hex form that WHATWG URL parsers (`new URL('https://[::127.0.0.1]/').hostname` → `[::7f00:1]`) emit for IPv4-Compatible literals. The more-specific `::/128` and `::1/128` ranges retain their existing `unspecified` and `loopback` classifications.
+
+
 ### 2.4.0 - 2026-05-03
 
 - remove Bower support

--- a/lib/ipaddr.d.ts
+++ b/lib/ipaddr.d.ts
@@ -1,7 +1,7 @@
 declare module "ipaddr.js" {
     type IPvXRangeDefaults = 'unicast' | 'unspecified' | 'multicast' | 'linkLocal' | 'loopback' | 'reserved' | 'benchmarking' | 'amt';
     type IPv4Range = IPvXRangeDefaults | 'broadcast' | 'carrierGradeNat' | 'private' | 'as112';
-    type IPv6Range = IPvXRangeDefaults | 'uniqueLocal' | 'ipv4Mapped' | 'rfc6145' | 'rfc6052' | '6to4' | 'teredo' | 'as112v6' | 'orchid2' | 'droneRemoteIdProtocolEntityTags';
+    type IPv6Range = IPvXRangeDefaults | 'uniqueLocal' | 'ipv4Mapped' | 'ipv4Compat' | 'rfc6145' | 'rfc6052' | '6to4' | 'teredo' | 'as112v6' | 'orchid2' | 'droneRemoteIdProtocolEntityTags';
 
     interface RangeList<T> {
         [name: string]: [T, number] | [T, number][];

--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -567,6 +567,13 @@
             loopback: [new IPv6([0, 0, 0, 0, 0, 0, 0, 1]), 128],
             uniqueLocal: [new IPv6([0xfc00, 0, 0, 0, 0, 0, 0, 0]), 7],
             ipv4Mapped: [new IPv6([0, 0, 0, 0, 0, 0xffff, 0, 0]), 96],
+            // RFC4291 Section 2.5.5.1 ("IPv4-Compatible IPv6 Address"). Deprecated
+            // but still classified as a non-unicast range so consumers using
+            // range() !== 'unicast' as a safety check (e.g. SSRF filters) treat
+            // ::a.b.c.d the same way they treat ::ffff:a.b.c.d. Placed after
+            // unspecified (::/128) and loopback (::1/128) so those keep their
+            // more-specific classifications.
+            ipv4Compat: [new IPv6([0, 0, 0, 0, 0, 0, 0, 0]), 96],
             // RFC3879
             deprecatedSiteLocal: [new IPv6([0xfec0, 0, 0, 0, 0, 0, 0, 0]), 10],
             // RFC6666

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -420,6 +420,23 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv6.parse('100::42').range(), 'discard');
         assert.equal(ipaddr.IPv6.parse('fc00::').range(), 'uniqueLocal');
         assert.equal(ipaddr.IPv6.parse('::ffff:192.168.1.10').range(), 'ipv4Mapped');
+        // RFC4291 §2.5.5.1 IPv4-Compatible IPv6 addresses (::/96, excluding ::
+        // and ::1). Deprecated but must not be reported as plain unicast, since
+        // dual-stack hosts may route them to the embedded IPv4 destination. Note
+        // that IPv6.parse() rewrites dotted-quad forms ("::127.0.0.1") into the
+        // mapped form ("::ffff:7f00:1"); the realistic input shape for this
+        // range is therefore pure-hex, which is also what WHATWG URL parsers
+        // produce for the IPv4-compatible literal.
+        assert.equal(ipaddr.IPv6.parse('::7f00:1').range(), 'ipv4Compat');
+        assert.equal(ipaddr.IPv6.parse('0:0:0:0:0:0:7f00:1').range(), 'ipv4Compat');
+        assert.equal(ipaddr.IPv6.parse('::a00:1').range(), 'ipv4Compat');
+        assert.equal(ipaddr.IPv6.parse('::a9fe:a9fe').range(), 'ipv4Compat');
+        assert.equal(ipaddr.IPv6.parse('::808:808').range(), 'ipv4Compat');
+        // The more-specific ::/128 and ::1/128 ranges keep their existing labels.
+        // (Asserted above; restated here as a regression guard against the new
+        // ::/96 entry shadowing them.)
+        assert.equal(ipaddr.IPv6.parse('::').range(), 'unspecified');
+        assert.equal(ipaddr.IPv6.parse('::1').range(), 'loopback');
         assert.equal(ipaddr.IPv6.parse('fec0::1234').range(), 'deprecatedSiteLocal');
         assert.equal(ipaddr.IPv6.parse('::ffff:0:192.168.1.10').range(), 'rfc6145');
         assert.equal(ipaddr.IPv6.parse('64:ff9b::1234').range(), 'rfc6052');


### PR DESCRIPTION
## Summary

`IPv6.prototype.range()` currently returns `'unicast'` for IPv4-Compatible IPv6 addresses (`::/96`, RFC4291 §2.5.5.1) other than the more-specific `::` and `::1`. This PR adds a new `ipv4Compat` entry to `IPv6.SpecialRanges` so callers using `range() !== 'unicast'` as a reserved-range / SSRF safety check correctly reject `::7f00:1`, `::a9fe:a9fe`, `::a00:1`, etc.

## Why this matters

The IPv4-Compatible form is deprecated, but it's still emitted by every WHATWG URL parser I checked, including Node's built-in `URL`:

```js
new URL('https://[::127.0.0.1]/').hostname
// → '[::7f00:1]'      ← IPv4-Compatible (pure-hex)

new URL('https://[::ffff:127.0.0.1]/').hostname
// → '[::ffff:7f00:1]' ← IPv4-Mapped (handled today)
```

So a caller that does the natural thing — `URL.hostname` → strip brackets → `ipaddr.process(...).range()` — gets `'unicast'` for `[::127.0.0.1]` and lets the request through, even though many dual-stack kernels will route the connection to `127.0.0.1`. This is the same shape of bypass `ipv4Mapped` already protects against; `ipv4Compat` was just the half of the pair that hadn't been added yet.

A few `ipv4Compat`-encoded payloads with real-world impact:

| Literal | Decodes to |
|---|---|
| `https://[::7f00:1]/` | `127.0.0.1` (loopback) |
| `https://[::a9fe:a9fe]/` | `169.254.169.254` (AWS / GCP instance metadata) |
| `https://[::a00:1]/` | `10.0.0.1` (RFC1918) |
| `https://[::c0a8:1]/` | `192.168.0.1` (RFC1918) |

## Changes

- Add `ipv4Compat: [new IPv6([0, 0, 0, 0, 0, 0, 0, 0]), 96]` to `IPv6.prototype.SpecialRanges`, positioned **after** `unspecified` (`::/128`) and `loopback` (`::1/128`). `subnetMatch` returns the first hit in insertion order, so `::` and `::1` keep their existing labels; only the rest of `::/96` is newly classified.
- Add `'ipv4Compat'` to the `IPv6Range` type union in `lib/ipaddr.d.ts`.
- Add assertions in `test/ipaddr.test.js` for the new range and for the unchanged `::` / `::1` classifications (regression guard).
- Changelog entry under `Unreleased`.

## Disjointness check

The new `::/96` is disjoint from the other /96-ish IPv6 ranges already in the table (so the entry doesn't accidentally re-classify any existing address):

| Range | Prefix | First 96 bits |
|---|---|---|
| `ipv4Compat` (new) | `::/96` | all zero |
| `ipv4Mapped` | `::ffff:0:0/96` | zero then `ffff` at bits 80–95 |
| `rfc6145` | `::ffff:0:0:0/96` | zero then `ffff` at bits 64–79 |
| `rfc6052` | `64:ff9b::/96` | starts `0064:ff9b` |
| `discard` | `100::/64` | starts `0100` |

## Parser note (worth documenting somewhere, not changed here)

`ipaddr.IPv6.parse('::127.0.0.1')` rewrites dotted-quad literals into the IPv4-Mapped form `::ffff:7f00:1`. So inside `ipaddr.js`, the new range is only reachable via the pure-hex form (`::7f00:1`, `0:0:0:0:0:0:7f00:1`). That's also the form WHATWG URL parsers produce for IPv4-Compatible literals, so it lines up with where the security impact actually lives, but it's a slightly counter-intuitive interaction. Happy to add a parser note in a follow-up if useful.

## Test plan

- [x] `npm test` — 61 pass, 0 fail
- [x] `npm run lint` — clean
- [x] Verified `::` → `unspecified` and `::1` → `loopback` regress nothing (asserted in tests)
- [x] Verified `::ffff:*` still returns `ipv4Mapped` (existing assertion left in place; `ipv4Compat` doesn't overlap)