### PR TITLE
fix: compress the leftmost zero run in toString (RFC 5952, 4.2.3)

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -775,10 +775,17 @@
             const string = this.toNormalizedString();
             let bestMatchIndex = 0;
             let bestMatchLength = -1;
+            let bestMatchGroups = -1;
             let match;
 
             while ((match = regex.exec(string))) {
-                if (match[0].length > bestMatchLength) {
+                // Compare by the number of zero groups, not the matched length:
+                // a run that is not at the start carries a leading ":" in the
+                // match, so an equal-length run later in the address would
+                // otherwise be preferred over the leftmost one (RFC 5952, 4.2.3).
+                const groups = (match[0].match(/0/g) || []).length;
+                if (groups > bestMatchGroups) {
+                    bestMatchGroups = groups;
                     bestMatchIndex = match.index;
                     bestMatchLength = match[0].length;
                 }

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -216,6 +216,11 @@ describe('ipaddr', () => {
         assert.equal(new ipaddr.IPv6([0, 0, 0xff, 0, 0, 0, 0, 0]).toString(), '0:0:ff::');
         assert.equal(new ipaddr.IPv6([0, 0, 0, 0, 0, 0xff, 0, 0]).toString(), '::ff:0:0');
         assert.equal(new ipaddr.IPv6([0, 0, 0, 0xff, 0xff, 0, 0, 0]).toString(), '::ff:ff:0:0:0');
+        // RFC 5952, 4.2.3: on equal-length runs the leftmost is compressed,
+        // including when that run is at the start of the address.
+        assert.equal(new ipaddr.IPv6([0, 0, 0xff, 0xff, 0, 0, 0xff, 0xff]).toString(), '::ff:ff:0:0:ff:ff');
+        assert.equal(new ipaddr.IPv6([0, 0, 1, 0, 0, 1, 0, 0]).toString(), '::1:0:0:1:0:0');
+        assert.equal(new ipaddr.IPv6([0x2001, 0xdb8, 0, 0, 1, 0, 0, 1]).toString(), '2001:db8::1:0:0:1');
         assert.equal(new ipaddr.IPv6([0x2001, 0xdb8, 0xff, 0xabc, 0xdef, 0x123b, 0x456c, 0x78d]).toString(), '2001:db8:ff:abc:def:123b:456c:78d');
         assert.equal(new ipaddr.IPv6([0x2001, 0xdb8, 0xff, 0xabc, 0, 0x123b, 0x456c, 0x78d]).toString(), '2001:db8:ff:abc:0:123b:456c:78d');
         assert.equal(new ipaddr.IPv6([0x2001, 0xdb8, 0xff, 0xabc, 0, 0, 0x456c, 0x78d]).toString(), '2001:db8:ff:abc::456c:78d');


### PR DESCRIPTION
## Problem

When an IPv6 address has several equal-length runs of zero groups, `toString()` does not always compress the leftmost one, contrary to RFC 5952, 4.2.3 ("When the length of the consecutive 16-bit 0 fields are equal … the first sequence of zero bits MUST be shortened").

```js
ipaddr.parse('0:0:1:0:0:1:0:0').toString();          // "0:0:1::1:0:0"  — should be "::1:0:0:1:0:0"
ipaddr.parse('0:0:ff:ff:0:0:ff:ff').toString();      // "0:0:ff:ff::ff:ff" — should be "::ff:ff:0:0:ff:ff"
```

It only goes wrong when the leftmost longest run is at the **start** of the address; a leading run vs. a trailing run was already handled correctly.

## Root cause

`toRFC5952String` ranks candidate runs by `match[0].length`:

```js
const regex = /((^|:)(0(:|$)){2,})/g;
while ((match = regex.exec(string))) {
    if (match[0].length > bestMatchLength) { … }
}
```

The regex's `(^|:)` prefix is empty for a run at the start (the `^` anchor is zero-width) but a literal `":"` for a run elsewhere. So a middle run of N zero groups matches `:0:0…` (2N+1 chars) while an equal run at the start matches `0:0…` (2N chars) — the middle run looks longer and is preferred, skipping the leftmost run.

## Fix

Rank by the number of zero groups (position-independent) rather than the matched string length, keeping `match[0].length` only for the substring offset:

```js
const groups = (match[0].match(/0/g) || []).length;
if (groups > bestMatchGroups) { … }
```

`>` still selects the first run on a tie, so the leftmost longest run wins.

## Test plan

- Added assertions to the IPv6 `toString` test for leading-vs-middle ties (fail on the current code, pass with the fix), including the RFC 5952 example `2001:db8:0:0:1:0:0:1 → 2001:db8::1:0:0:1`.
- A differential check over 300k generated IPv6 addresses (vs `ip-address`'s RFC 5952 output) found 4204 mismatches, all this case; the fix brings it to zero with no regressions. `node --test` green (61), `eslint` clean.
