### PR TITLE
fix(ipaddr): strict IPv6 validation — reject :: with zero compression and hextets >4 hex digits

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -61,8 +61,9 @@
             colonCount--;
         }
 
-        // The following loop would hang if colonCount > parts
-        if (colonCount > parts) {
+        // An address must not contain more separators than available parts,
+        // and :: must compress at least one part.
+        if (colonCount >= parts) {
             return null;
         }
 
@@ -91,7 +92,7 @@
             const results = [];
 
             for (let i = 0; i < ref.length; i++) {
-                results.push(parseInt(ref[i], 16));
+                results.push(ref[i].length > 4 ? NaN : parseInt(ref[i], 16));
             }
 
             return results;

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -336,6 +336,18 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv6.isValid(undefined), false);
     })
 
+    it('rejects IPv6 parts longer than four hexadecimal digits', () => {
+        assert.equal(ipaddr.IPv6.isValid('00000::1'), false);
+        assert.throws(() => ipaddr.IPv6.parse('00000::1'));
+    })
+
+    it('rejects compression of zero IPv6 parts', () => {
+        assert.equal(ipaddr.IPv6.isValid('1:2:3:4:5:6:7:8::'), false);
+        assert.throws(() => ipaddr.IPv6.parse('1:2:3:4:5:6:7:8::'));
+        assert.equal(ipaddr.IPv6.isValid('::1:2:3:4:5:6:7:8'), false);
+        assert.throws(() => ipaddr.IPv6.parse('::1:2:3:4:5:6:7:8'));
+    })
+
     it('validates IPv6 addresses in CIDR notation', () => {
         assert.equal(ipaddr.IPv6.isValidCIDR('::/0'), true);
         assert.equal(ipaddr.IPv6.isValidCIDR('2001:db8:F53A::1%z/64'), true);

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -339,6 +339,8 @@ describe('ipaddr', () => {
     it('rejects IPv6 parts longer than four hexadecimal digits', () => {
         assert.equal(ipaddr.IPv6.isValid('00000::1'), false);
         assert.throws(() => ipaddr.IPv6.parse('00000::1'));
+        assert.equal(ipaddr.IPv6.isValid('00000:0:0:0:0:0:1.2.3.4'), false);
+        assert.throws(() => ipaddr.IPv6.parse('00000:0:0:0:0:0:1.2.3.4'));
     })
 
     it('rejects compression of zero IPv6 parts', () => {
@@ -346,6 +348,11 @@ describe('ipaddr', () => {
         assert.throws(() => ipaddr.IPv6.parse('1:2:3:4:5:6:7:8::'));
         assert.equal(ipaddr.IPv6.isValid('::1:2:3:4:5:6:7:8'), false);
         assert.throws(() => ipaddr.IPv6.parse('::1:2:3:4:5:6:7:8'));
+    })
+
+    it('does not reject compression of exactly one IPv6 part', () => {
+        assert.equal(ipaddr.IPv6.isValid('1:2:3:4:5:6:7::'), true);
+        assert.equal(ipaddr.IPv6.isValid('::1:2:3:4:5:6:7'), true);
     })
 
     it('validates IPv6 addresses in CIDR notation', () => {


### PR DESCRIPTION
Closes #205

## Changes

### `lib/ipaddr.js`
1. **`colonCount > parts` → `colonCount >= parts`** — reject IPv6 addresses where :: compresses zero parts (e.g. `1:2:3:4:5:6:7:8::`, `::1:2:3:4:5:6:7:8`), per RFC 4291
2. **Hextet length check** — reject hextets longer than 4 hexadecimal digits (e.g. `00000::1`), per RFC 4291 section 2.2

### `test/ipaddr.test.js`
- Added test: "rejects IPv6 parts longer than four hexadecimal digits"
- Added test coverage for IPv4-embedded IPv6 with overlong hextets
- Added test: "rejects compression of zero IPv6 parts"
- Added regression test to ensure compression of exactly one IPv6 part remains valid