### PR TITLE
fix: reject non-numeric prefix length in subnetMaskFromPrefixLength

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -508,7 +508,7 @@
     // A utility function to return subnet mask in IPv4 format given the prefix length
     ipaddr.IPv4.subnetMaskFromPrefixLength = function (prefix) {
         prefix = parseInt(prefix);
-        if (prefix < 0 || prefix > 32) {
+        if (Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
             throw new Error('ipaddr: invalid IPv4 prefix length');
         }
 
@@ -968,7 +968,7 @@
     // A utility function to return subnet mask in IPv6 format given the prefix length
     ipaddr.IPv6.subnetMaskFromPrefixLength = function (prefix) {
         prefix = parseInt(prefix);
-        if (prefix < 0 || prefix > 128) {
+        if (Number.isNaN(prefix) || prefix < 0 || prefix > 128) {
             throw new Error('ipaddr: invalid IPv6 prefix length');
         }
 

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -668,6 +668,15 @@ describe('ipaddr', () => {
         assert.equal(ipaddr.IPv6.subnetMaskFromPrefixLength(0),   '::');
     })
 
+    it('subnetMaskFromPrefixLength throws on an out-of-range or non-numeric prefix length', () => {
+        assert.throws(() => ipaddr.IPv4.subnetMaskFromPrefixLength(-1));
+        assert.throws(() => ipaddr.IPv4.subnetMaskFromPrefixLength(33));
+        assert.throws(() => ipaddr.IPv4.subnetMaskFromPrefixLength('not a number'));
+        assert.throws(() => ipaddr.IPv6.subnetMaskFromPrefixLength(-1));
+        assert.throws(() => ipaddr.IPv6.subnetMaskFromPrefixLength(129));
+        assert.throws(() => ipaddr.IPv6.subnetMaskFromPrefixLength('not a number'));
+    })
+
     it('broadcastAddressFromCIDR returns correct IPv4 broadcast address', () => {
         assert.equal(ipaddr.IPv4.broadcastAddressFromCIDR('172.0.0.1/24'), '172.0.0.255');
         assert.equal(ipaddr.IPv4.broadcastAddressFromCIDR('172.0.0.1/26'), '172.0.0.63');


### PR DESCRIPTION
`IPv4.subnetMaskFromPrefixLength` and its IPv6 counterpart validate the prefix with `prefix < 0 || prefix > 32` (128 for IPv6) and throw `ipaddr: invalid ... prefix length` when it is out of range. The value first goes through `parseInt(prefix)`, so a non-numeric argument becomes `NaN`, and every comparison against `NaN` is false. The guard is skipped and the function returns a bogus all-zero mask instead of throwing:

```js
ipaddr.IPv4.subnetMaskFromPrefixLength('abc')      // => '0.0.0.0'
ipaddr.IPv4.subnetMaskFromPrefixLength(undefined)  // => '0.0.0.0'
ipaddr.IPv6.subnetMaskFromPrefixLength('foo')      // => '::'
```

For comparison, `parseCIDR` validates the same kind of value with `maskLength >= 0 && maskLength <= 32`, which already rejects `NaN` (because `NaN >= 0` is false). The two checks should agree.

This adds a `Number.isNaN` check to both guards so a non-numeric prefix throws the same error as an out-of-range one, and adds a test covering out-of-range and non-numeric input for IPv4 and IPv6. `node --test` passes.
