### PR TITLE
fix: throw a descriptive error for malformed input in IPv6.parse

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -896,7 +896,7 @@
     ipaddr.IPv6.parse = function (string) {
         const addr = this.parser(string);
 
-        if (addr.parts === null) {
+        if (addr === null) {
             throw new Error('ipaddr: string is not formatted like an IPv6 Address');
         }
 
@@ -939,7 +939,7 @@
                 addr = addr.slice(0, -1)
             }
             addr = expandIPv6(addr + zoneId, 6);
-            if (addr.parts) {
+            if (addr && addr.parts) {
                 octets = [
                     parseInt(match[2]),
                     parseInt(match[3]),

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -387,6 +387,12 @@ describe('ipaddr', () => {
         });
     })
 
+    it('throws a descriptive error when parsing a malformed IPv6 address', () => {
+        assert.throws(() => ipaddr.IPv6.parse('foobar'), /string is not formatted like an IPv6 Address/);
+        assert.throws(() => ipaddr.IPv6.parse('::ffff:999.1.1.1'), /string is not formatted like an IPv6 Address/);
+        assert.throws(() => ipaddr.IPv6.parse('1::2::3:1.2.3.4'), /string is not formatted like an IPv6 Address/);
+    })
+
     it('matches IPv6 CIDR correctly', () => {
         let addr = ipaddr.IPv6.parse('2001:db8:f53a::1');
         assert.equal(addr.match(ipaddr.IPv6.parse('::'), 0), true);


### PR DESCRIPTION
`IPv6.parser` returns `null` for unrecognized input, but `IPv6.parse` checked `addr.parts === null` and the transitional branch dereferenced `addr.parts` on a null result, so malformed input threw a bare `TypeError` instead of the documented error:

```js
ipaddr.IPv6.parse('foobar') // TypeError: Cannot read properties of null (reading 'parts')
```

`IPv4.parse` already guards with `parts === null`; guard IPv6 against `null` too so malformed input throws `ipaddr: string is not formatted like an IPv6 Address`, as the method documents.
