### PR TITLE
fix: validate CIDR prefix lengths in match

### DIFF
--- a/lib/ipaddr.js
+++ b/lib/ipaddr.js
@@ -108,6 +108,16 @@ function matchCIDR (first, second, partSize, cidrBits) {
         throw new Error('ipaddr: cannot match CIDR for objects with different lengths');
     }
 
+    const maxCidrBits = first.length * partSize;
+
+    if (
+        !Number.isInteger(cidrBits) ||
+        cidrBits < 0 ||
+        cidrBits > maxCidrBits
+    ) {
+        throw new Error('ipaddr: invalid CIDR prefix length');
+    }
+
     let part = 0;
     let shift;
 

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -106,6 +106,39 @@ describe('ipaddr', () => {
         equal(addr.match(addr, 32), true);
     })
 
+    it('rejects invalid IPv4 CIDR prefix lengths in match', () => {
+        const address = IPv4.parse('8.8.8.8');
+        const network = IPv4.parse('192.168.1.0');
+
+        throws(() => {
+            address.match(network, -1);
+        });
+
+        throws(() => {
+            address.match(network, -0.5);
+        });
+
+        throws(() => {
+            address.match(network, NaN);
+        });
+
+        throws(() => {
+            address.match(network, Infinity);
+        });
+
+        throws(() => {
+            address.match(network, -Infinity);
+        });
+
+        throws(() => {
+            address.match(network, 24.9);
+        });
+
+        throws(() => {
+            address.match(network, 33);
+        });
+    })
+
     it('parses CIDR reversible', () => {
         equal(parseCIDR('1.2.3.4/24').toString(), '1.2.3.4/24');
         equal(parseCIDR('::1%zone/24').toString(), '::1%zone/24');
@@ -176,6 +209,39 @@ describe('ipaddr', () => {
     it('can construct IPv6 from 16bit parts', () => {
         doesNotThrow(() => {
             new IPv6([0x2001, 0xdb8, 0xf53a, 0, 0, 0, 0, 1]);
+        });
+    })
+
+    it('rejects invalid IPv6 CIDR prefix lengths in match', () => {
+        const address = IPv6.parse('2001:db8::1');
+        const network = IPv6.parse('2001:db8::');
+
+        throws(() => {
+            address.match(network, -1);
+        });
+
+        throws(() => {
+            address.match(network, -0.5);
+        });
+
+        throws(() => {
+            address.match(network, NaN);
+        });
+
+        throws(() => {
+            address.match(network, Infinity);
+        });
+
+        throws(() => {
+            address.match(network, -Infinity);
+        });
+
+        throws(() => {
+            address.match(network, 64.9);
+        });
+
+        throws(() => {
+            address.match(network, 129);
         });
     })
 
@@ -564,6 +630,50 @@ describe('ipaddr', () => {
         let rangelist = { dual64: [parseCIDR('1.2.4.0/24'), parseCIDR('2001:1:2:3::/64')] };
         equal(subnetMatch(new IPv4([1, 2, 4, 1]), rangelist, false), 'dual64');
         equal(subnetMatch(new IPv6([0x2001, 1, 2, 3, 0, 0, 0, 1]), rangelist, false), 'dual64');
+    })
+
+    it('subnetMatch rejects invalid CIDR prefix lengths', () => {
+        const address = IPv4.parse('8.8.8.8');
+        const network = IPv4.parse('192.168.1.0');
+
+        throws(() => {
+            subnetMatch(
+                address,
+                {
+                    internal: [
+                        network,
+                        -1
+                    ]
+                },
+                'external'
+            );
+        });
+
+        throws(() => {
+            subnetMatch(
+                address,
+                {
+                    internal: [
+                        network,
+                        NaN
+                    ]
+                },
+                'external'
+            );
+        });
+
+        throws(() => {
+            subnetMatch(
+                address,
+                {
+                    internal: [
+                        network,
+                        Infinity
+                    ]
+                },
+                'external'
+            );
+        });
     })
 
     it('is able to determine IP address type from byte array input', () => {

--- a/test/ipaddr.test.js
+++ b/test/ipaddr.test.js
@@ -110,33 +110,13 @@ describe('ipaddr', () => {
         const address = IPv4.parse('8.8.8.8');
         const network = IPv4.parse('192.168.1.0');
 
-        throws(() => {
-            address.match(network, -1);
-        });
-
-        throws(() => {
-            address.match(network, -0.5);
-        });
-
-        throws(() => {
-            address.match(network, NaN);
-        });
-
-        throws(() => {
-            address.match(network, Infinity);
-        });
-
-        throws(() => {
-            address.match(network, -Infinity);
-        });
-
-        throws(() => {
-            address.match(network, 24.9);
-        });
-
-        throws(() => {
-            address.match(network, 33);
-        });
+        throws(() => address.match(network, -1));
+        throws(() => address.match(network, -0.5));
+        throws(() => address.match(network, NaN));
+        throws(() => address.match(network, Infinity));
+        throws(() => address.match(network, -Infinity));
+        throws(() => address.match(network, 24.9));
+        throws(() => address.match(network, 33));
     })
 
     it('parses CIDR reversible', () => {
@@ -216,33 +196,13 @@ describe('ipaddr', () => {
         const address = IPv6.parse('2001:db8::1');
         const network = IPv6.parse('2001:db8::');
 
-        throws(() => {
-            address.match(network, -1);
-        });
-
-        throws(() => {
-            address.match(network, -0.5);
-        });
-
-        throws(() => {
-            address.match(network, NaN);
-        });
-
-        throws(() => {
-            address.match(network, Infinity);
-        });
-
-        throws(() => {
-            address.match(network, -Infinity);
-        });
-
-        throws(() => {
-            address.match(network, 64.9);
-        });
-
-        throws(() => {
-            address.match(network, 129);
-        });
+        throws(() => address.match(network, -1));
+        throws(() => address.match(network, -0.5));
+        throws(() => address.match(network, NaN));
+        throws(() => address.match(network, Infinity));
+        throws(() => address.match(network, -Infinity));
+        throws(() => address.match(network, 64.9));
+        throws(() => address.match(network, 129));
     })
 
     it('can construct IPv6 from 8bit parts', () => {
@@ -636,44 +596,9 @@ describe('ipaddr', () => {
         const address = IPv4.parse('8.8.8.8');
         const network = IPv4.parse('192.168.1.0');
 
-        throws(() => {
-            subnetMatch(
-                address,
-                {
-                    internal: [
-                        network,
-                        -1
-                    ]
-                },
-                'external'
-            );
-        });
-
-        throws(() => {
-            subnetMatch(
-                address,
-                {
-                    internal: [
-                        network,
-                        NaN
-                    ]
-                },
-                'external'
-            );
-        });
-
-        throws(() => {
-            subnetMatch(
-                address,
-                {
-                    internal: [
-                        network,
-                        Infinity
-                    ]
-                },
-                'external'
-            );
-        });
+        throws(() => subnetMatch(address, { internal: [network, -1] }, 'external'));
+        throws(() => subnetMatch(address, { internal: [network, NaN] }, 'external'));
+        throws(() => subnetMatch(address, { internal: [network, Infinity] }, 'external'));
     })
 
     it('is able to determine IP address type from byte array input', () => {


### PR DESCRIPTION
\## Summary



`match()` did not validate CIDR prefix lengths before passing them to `matchCIDR()`.



Invalid values could therefore produce unexpected behavior:



\- negative values and `NaN` could result in an unconditional match;

\- fractional prefix lengths were accepted with inconsistent matching semantics;

\- values above the IPv4/IPv6 prefix range were not rejected;

\- `Infinity` could cause non-termination for certain inputs.



This also affected `subnetMatch()`, since it delegates CIDR comparisons to `match()`.



\## Fix



Validate that `cidrBits` is:



\- an integer;

\- greater than or equal to `0`;

\- less than or equal to the address bit length (`32` for IPv4 and `128` for IPv6).



Invalid prefix lengths now throw:



```text

ipaddr: invalid CIDR prefix length



```



\## Tests



Added regression tests covering invalid CIDR prefix lengths for:



\- IPv4 `match()`;

\- IPv6 `match()`;

\- `subnetMatch()`.



The full test suite passes:



```text

70 tests

70 pass

0 fail

```

